### PR TITLE
Publish release version

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -32,11 +32,3 @@ jobs:
       env:
         USERNAME: ${{ github.actor }}
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-    # the publishing section of your build.gradle
-    - name: Publish to GitHub Packages
-      run: gradle publish
-      env:
-        USERNAME: ${{ github.actor }}
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,6 +14,9 @@ plugins {
     id 'net.researchgate.release' version '2.8.1'
 }
 
+// Needed to run publish before committing the new snapshot version.
+afterReleaseBuild.dependsOn publish
+
 publishing {
     repositories {
         maven {


### PR DESCRIPTION
Running publish after committing the snapshot tag means we publish our snapshots. This is not ideal.